### PR TITLE
从用户态到内核态的切换

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
 			"devDependencies": {
 				"@istanbuljs/nyc-config-typescript": "^1.0.2",
 				"@types/mocha": "^5.2.6",
-				"@types/node": "^11.11.3",
+				"@types/node": "^11.15.54",
 				"@types/vscode": "^1.55.0",
 				"@typescript-eslint/eslint-plugin": "^5.22.0",
 				"@typescript-eslint/parser": "^5.22.0",

--- a/package.json
+++ b/package.json
@@ -54,12 +54,12 @@
 				},
 				{
 					"when": "resourceLangId == rust",
-					"command": "code-debug.disableCurrentSpaceBreakpoints",
+					"command": "code-debug.goToKernel",
 					"group": "navigation"
 				},
 				{
 					"when": "resourceLangId == rust",
-					"command": "code-debug.updateAllSpacesBreakpointsInfo",
+					"command": "code-debug.disableCurrentSpaceBreakpoints",
 					"group": "navigation"
 				}
 			]
@@ -104,19 +104,19 @@
 				}
 			},
 			{
+				"command": "code-debug.goToKernel",
+				"title": "go to kernel ",
+				"icon": {
+					"dark": "images/update-all-spaces-breakpoints-info-dark.svg",
+					"light": "images/update-all-spaces-breakpoints-info-light.svg"
+				}
+			},
+			{
 				"command": "code-debug.disableCurrentSpaceBreakpoints",
 				"title": "Disable Current Space Breakpoints",
 				"icon": {
 					"dark": "images/disable-current-space-breakpoints-dark.svg",
 					"light": "images/disable-current-space-breakpoints-light.svg"
-				}
-			},
-			{
-				"command": "code-debug.updateAllSpacesBreakpointsInfo",
-				"title": "Update All Spaces Breakpoints Info",
-				"icon": {
-					"dark": "images/update-all-spaces-breakpoints-info-dark.svg",
-					"light": "images/update-all-spaces-breakpoints-info-light.svg"
 				}
 			}
 		],
@@ -408,7 +408,7 @@
 	"devDependencies": {
 		"@istanbuljs/nyc-config-typescript": "^1.0.2",
 		"@types/mocha": "^5.2.6",
-		"@types/node": "^11.11.3",
+		"@types/node": "^11.15.54",
 		"@types/vscode": "^1.55.0",
 		"@typescript-eslint/eslint-plugin": "^5.22.0",
 		"@typescript-eslint/parser": "^5.22.0",


### PR DESCRIPTION
注释掉了updateAllSpacesBreakpointsInfo按钮，把他设置成了“go to kernel”
“go to kernel”做的事情：

1. 调用disableCurrentSpaceBreakpoints
2. 设置内核出入口断点，只把内核的入口断点的spacename设置成“0”，在设置断点的setBreakPointsRequest中如果发现spacename为“0”，就立即通知gdb设置断点，出口断点的spacename还是“kernel”
3. 更新debugFilepath
4. 更新当前地址空间为“kernel”

现在的状态：在进入用户态以后点击“go to kernel”按钮，点击继续按钮，能够进入内核态，进入内核态以后，能够在内核中设置断点，并且能够暂停到该断点，当执行到内核出口断点，再点击继续按钮，能够回到用户态。